### PR TITLE
Update version to 1.1.1 and add .ts.map extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.1
+
+- Added .ts.map extension
+
 # v1.1.0
 
 - Added `tsmap.svg` icon

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscicons",
   "displayName": "Icons – Maintained",
   "description": "Beautiful file and folder icons for Visual Studio Code",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "yusifaliyevpro",
   "main": "./out/extension.js",
   "engines": {

--- a/src/icons/fileExtensions.ts
+++ b/src/icons/fileExtensions.ts
@@ -120,6 +120,7 @@ export default {
   csx: "_f_csharp",
   cts: "_f_typescript",
   "cts.map": "_f_tsmap",
+  "ts.map": "_f_tsmap",
   cu: "_f_cuda",
   cuh: "_f_cuda",
   cxx: "_f_cpp",


### PR DESCRIPTION
## What does this PR do?

Updates the version to 1.1.1 and adds support for the .ts.map file extension.

## Type

- [ ] New icon(s)
- [ ] Icon update
- [ ] Bug fix
- [x] Other

## Checklist

- [x] SVG files added to `icons/`
- [x] Icon registered in `src/icons.ts`
- [x] Mappings added in the appropriate `src/icons/` file
- [x] `pnpm pre-check` passes
- [x] No changes to `version` in `package.json`

## Screenshots

<!-- Show the new/updated icons in the file explorer if applicable -->

