### PR TITLE
Release version 1.1.6 with precommit icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.6
+
+- Added the `precommit` icon and related extensions and file names by @JvictorMarques
+
 # v1.1.5
 
 - Added `eas.json` and `metro.config` files' icon

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscicons",
   "displayName": "Icons – Maintained",
   "description": "Beautiful file and folder icons for Visual Studio Code",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "publisher": "yusifaliyevpro",
   "main": "./out/extension.js",
   "engines": {


### PR DESCRIPTION
## What does this PR do?

Adds the `precommit` icon along with related extensions and updates the version to 1.1.6.

## Type

- [x] New icon(s)
- [ ] Icon update
- [ ] Bug fix
- [ ] Other

## Checklist

- [x] SVG files added to `icons/`
- [x] Icon registered in `src/icons.ts`
- [x] Mappings added in the appropriate `src/icons/` file
- [x] `pnpm check` passes
- [x] No changes to `version` in `package.json`

## Screenshots

<!-- Show the new/updated icons in the file explorer if applicable -->

