### PR TITLE
fix(icons): add eslint.config.ts file icon mapping

### DIFF
--- a/src/icons/fileNames.ts
+++ b/src/icons/fileNames.ts
@@ -274,6 +274,7 @@ export default {
   "eslint.config.cjs": "_f_eslint",
   "eslint.config.js": "_f_eslint",
   "eslint.config.mjs": "_f_eslint",
+  "eslint.config.ts": "_f_eslint",
   ".eslintcache": "_f_eslint",
   ".eslintignore": "_f_eslint",
   ".eslintrc": "_f_eslint",


### PR DESCRIPTION
## What does this PR do?

This PR adds support for eslint.config.ts in the file-name icon mappings, reusing the existing ESLint icon id (_f_eslint).

Why:
eslint.config.js/.cjs/.mjs are already mapped to the ESLint icon, but eslint.config.ts was missing, so TypeScript-based flat config files showed a generic icon.

Scope:

One-line mapping addition in src/icons/fileNames.ts
No icon assets changed
No behavior changes outside file icon lookup
Risk:
Very low. This follows the existing ESLint mapping pattern and only adds a missing filename variant.

Validation:

pnpm check passed (type-check, format, lint, icon integrity, build).
## Type

- [ ] New icon(s)
- [x] Icon update
- [ ] Bug fix
- [ ] Other

## Checklist

- [ ] SVG files added to `icons/` (if applicable)
- [ ] Icon registered in `src/icons.ts` (if applicable)
- [x] Mappings added in the appropriate `src/icons/` file (if applicable)
- [x] `pnpm check` passes (required)
- [x] No changes to `version` in `package.json` (required)

## Screenshots

<!-- Show the new/updated icons in the file explorer if applicable -->
